### PR TITLE
Better error messaging

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -188,7 +188,10 @@ class _Attribute(object):
                  'lattice'):
             self._setterKwargs['type'] = t
 
-    def __call__(self):
+    def __call__(self, *args):
+        if args:
+            raise AttributeError('Attempting to get an attribute %s, but you are passing attributes into the getter.'
+                                 'Are you trying to call a function and misspelled something?' % self)
         return self.get()
 
     def __getattr__(self, item):


### PR DESCRIPTION
https://github.com/peerke88/cmdWrapper/issues/2 Descriptive 
Error in `__call__()`, in case of calling a non-existent function (which became a getAttr so the error is confusing)
.
